### PR TITLE
Fix network capabilities and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Configure the receivers that Tempo will use to ingest tracing data.
 ```yaml
 - hosts: myorg_monitoring
   roles:
-    - role: grafana_tempo
+    - role: lfkdev.grafana_tempo
   tags:
     - tempo
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 
 tempo_version: "2.6.0" # update checksums if you change the version (no, don't remove the checksum check)
 tempo_os_arch: "linux_amd64"
+tempo_cap_net_bind_service: false
 tempo_listening_port: 3200
 
 # package names

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -22,9 +22,11 @@
   apt:
     deb: "/tmp/{{ tempo_package_deb }}"
 
-- name: Add network capabilities to Tempo binary on Debian
-  command: setcap 'cap_net_bind_service=+ep' /usr/bin/tempo
-  args:
-    warn: false
-  register: setcap_result
-  changed_when: setcap_result.rc != 0
+- name: "Enable tempo to ports lower than port 1024"
+  community.general.capabilities:
+    path: /usr/sbin/grafana-server
+    capability: CAP_NET_BIND_SERVICE+ep
+    state: present
+  when:
+    - "tempo_listening_port | int <= 1024"
+    - "tempo_cap_net_bind_service"

--- a/templates/tempo.yaml.j2
+++ b/templates/tempo.yaml.j2
@@ -25,7 +25,7 @@ metrics_generator:
 
 storage:
   trace:
-    {% if tempo_storage_s3_access_key %}
+{% if tempo_storage_s3_access_key %}
     backend: s3
     s3:
       endpoint: "{{ tempo_storage_s3_endpoint }}"


### PR DESCRIPTION
Hello there!

I was just about to create a role for Tempo when I came across yours! It works great, but I encountered a small issue with the step to add network capabilities to the Tempo binary on Debian, as well as with the configuration template.

I resolved the network capabilities issue by using the same method as in the [Grafana repository](https://github.com/grafana/grafana-ansible-collection/blob/fb6294c3c218194a8ab19943416c17ede1baa840/roles/grafana/tasks/configure.yml#L71), and it worked perfectly!

For the configuration template, it was simply a matter of fixing the indentation.

I also updated the example so that users running Ansible Galaxy commands will have the correct role name.