### PR TITLE
Enable S3 Storage Activation Based on Bucket Name and Add http_listen_address Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,18 @@ tempo_service_name: "tempo"
 The name of the Tempo service.
 
 ```yaml
+tempo_listening_address: 0.0.0.0
+```
+Specifies the IP address on which the HTTP server will listen for incoming requests.
+
+```yaml
 tempo_listening_port: 3200
 ```
 The port on which Tempo will listen for incoming HTTP requests.
 
 ```yaml
 tempo_storage_s3_endpoint: "s3.us-east-1.amazonaws.com"
-tempo_storage_s3_bucket: "grafana-traces-data"
+tempo_storage_s3_bucket: ""
 tempo_storage_s3_access_key: ""
 tempo_storage_s3_secret_key: ""
 tempo_storage_s3_insecure: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ tempo_version: "2.6.0" # update checksums if you change the version (no, don't r
 tempo_os_arch: "linux_amd64"
 tempo_cap_net_bind_service: false
 tempo_listening_port: 3200
+tempo_listening_address: 0.0.0.0
 
 # package names
 tempo_package_deb: "tempo_{{ tempo_version }}_{{ tempo_os_arch }}.deb"
@@ -23,8 +24,8 @@ tempo_service_name: "tempo"
 
 # storage
 tempo_storage_s3_endpoint: "s3.us-east-1.amazonaws.com"
-tempo_storage_s3_bucket: "grafana-traces-data"
-tempo_storage_s3_access_key: "" # if not defined, local storage will be used
+tempo_storage_s3_bucket: "" # if not defined, local storage will be used
+tempo_storage_s3_access_key: ""
 tempo_storage_s3_secret_key: ""
 tempo_storage_s3_insecure: true
 

--- a/templates/tempo.yaml.j2
+++ b/templates/tempo.yaml.j2
@@ -3,6 +3,7 @@
 
 server:
   http_listen_port: {{ tempo_listening_port }}
+  http_listen_address: {{ tempo_listening_address }}
 
 distributor:
   receivers:
@@ -25,7 +26,7 @@ metrics_generator:
 
 storage:
   trace:
-{% if tempo_storage_s3_access_key %}
+{% if tempo_storage_s3_bucket %}
     backend: s3
     s3:
       endpoint: "{{ tempo_storage_s3_endpoint }}"


### PR DESCRIPTION
**Description:**

This merge request introduces two main changes:

1. **S3 Storage Activation Based on Bucket Name:**
   - Currently, S3 storage is activated when an access key is inserted. However, this approach is not ideal for scenarios where IAM roles are used, which do not require an access key.
   - To address this, the activation of S3 storage will now be triggered by specifying a bucket name. This change ensures that S3 storage is enabled only when necessary, aligning with best practices for security and resource management.

2. **Addition of `http_listen_address` Parameter:**
   - The `http_listen_address` parameter has been added to allow for more flexible configuration of the HTTP listener. This parameter specifies the IP address on which the HTTP server will listen for incoming requests.

3. **Updated documentation to reflect these changes.**


Thank you ! 